### PR TITLE
Update MysticalAgri.zs

### DIFF
--- a/Client/overrides/scripts/MysticalAgri.zs
+++ b/Client/overrides/scripts/MysticalAgri.zs
@@ -1,13 +1,13 @@
-import crafttweaker.item.IItemStack;
 #MC Eternal Scripts
 
 print("--- loading MysticalAgri.zs ---");
 
 #Remove Items
-var nocraftseeds = [<mysticalagriculture:iron_seeds>,<mysticalagriculture:diamond_seeds>,<mysticalagriculture:gold_seeds>,<mysticalagriculture:blaze_seeds>,<mysticalagradditions:nether_star_seeds>] as ItemStack[];
-for seeds in nocraftseeds {
-	recipes.remove(seeds);
-}
+recipes.remove(<mysticalagriculture:iron_seeds>);
+recipes.remove(<mysticalagriculture:diamond_seeds>);
+recipes.remove(<mysticalagriculture:gold_seeds>);
+recipes.remove(<mysticalagriculture:blaze_seeds>);
+recipes.remove(<mysticalagradditions:nether_star_seeds>);
 
 #Add Shaped
 recipes.addShaped(<mysticalagriculture:iron_seeds>, [[<minecraft:iron_ingot>, <ore:essenceSupremium>, <minecraft:iron_ingot>], [<ore:essenceSupremium>, <mysticalagriculture:crafting:21>, <mysticalagriculture:crafting:4>], [<minecraft:iron_ingot>, <mysticalagriculture:crafting:4>, <minecraft:iron_ingot>]]);

--- a/Client/overrides/scripts/MysticalAgri.zs
+++ b/Client/overrides/scripts/MysticalAgri.zs
@@ -4,7 +4,7 @@ import crafttweaker.item.IItemStack;
 print("--- loading MysticalAgri.zs ---");
 
 #Remove Items
-var nocraftseeds = [<mysticalagriculture:iron_seeds>,<mysticalagriculture:diamond_seeds>,<mysticalagriculture:gold_seeds>,<mysticalagriculture:blaze_seeds>,<mysticalagradditions:nether_star_seeds>] as IItemStack[];
+var nocraftseeds = [<mysticalagriculture:iron_seeds>,<mysticalagriculture:diamond_seeds>,<mysticalagriculture:gold_seeds>,<mysticalagriculture:blaze_seeds>,<mysticalagradditions:nether_star_seeds>] as ItemStack[];
 for seeds in nocraftseeds {
 	recipes.remove(seeds);
 }


### PR DESCRIPTION
The way it was before there was an error with the variable for the for loop so I got rid of it 
Now the unlock able seeds are uncraftable like they should be and this red text is gone:
![Screen Shot 2021-08-05 at 9 52 03 AM](https://user-images.githubusercontent.com/80121423/128393234-b7ff4fd2-4fb8-4afa-af17-4464aa07585f.png)

 \- Mystic